### PR TITLE
Fix critical issues with service creation and DNS compliance

### DIFF
--- a/.github/workflows/merge_group,pull_request.go.yaml
+++ b/.github/workflows/merge_group,pull_request.go.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: [1.24]
+        go: [1.25]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: 🚧 Setup Golang ${{ matrix.go }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,7 +12,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.24.0
+    - go@1.25.0
     - node@18.20.5
     - python@3.10.8
     - rust@1.82.0

--- a/deploy/manifests/default/argotails.rbac.yaml
+++ b/deploy/manifests/default/argotails.rbac.yaml
@@ -12,7 +12,7 @@ metadata:
   name: argotails
 rules:
   - apiGroups: [""]
-    resources: [secrets]
+    resources: [service, secrets]
     verbs: [get, list, watch, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/chezmoidotsh/argotails
 
-go 1.24.0
-
-toolchain go1.25.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/kong v1.12.1


### PR DESCRIPTION
This pull request introduces a new utility function to ensure Kubernetes service names derived from device names are DNS-1035 compliant, and updates all relevant service creation, update, and deletion logic to use this function. Additionally, it expands RBAC permissions and adds thorough unit tests for the new naming logic.

**Service name normalization and usage:**

* Added the `toDNS1035Name` function in `internal/reconciler/reconciler.go` to convert device names to DNS-1035 compliant service names, enforcing Kubernetes naming requirements.
* Updated service creation, update, and deletion logic in `internal/reconciler/reconciler.go` to use `toDNS1035Name` for all service name references, ensuring consistency and compliance. [[1]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cL311-R358) [[2]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cL355-R406) [[3]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cL391-R446) [[4]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cL404-R459)

**Testing improvements:**

* Added comprehensive tests for `toDNS1035Name` in `internal/reconciler/reconciler_test.go`, covering various edge cases and validating DNS-1035 compliance.

**RBAC permissions update:**

* Modified `deploy/manifests/default/argotails.rbac.yaml` to grant access to the `service` resource in addition to `secrets`, allowing necessary operations on Kubernetes services.